### PR TITLE
Make vision fog use local items

### DIFF
--- a/main.js
+++ b/main.js
@@ -166,8 +166,13 @@ async function initScene()
 // Setup extension add-ons
 OBR.onReady(() => {
   OBR.player.getRole().then(async value => {
-    // But only if user is the GM
-    if (value == "GM") {
+    // Allow the extension to load for any player
+    // This is now needed because each player updates their own
+    // local fog paths.
+    // If you don't wish to show the UI here for players
+    // then the UI should probably be hidden and an
+    // information message displayed
+    if (value == "GM" || value == "PLAYER") {
       setButtonHandler();
       setupContextMenus();
       createTool();

--- a/visionTool.js
+++ b/visionTool.js
@@ -249,6 +249,8 @@ async function computeShadow(event) {
     busy = false;
     return;
   }
+
+  const localItems = await OBR.scene.local.getItems();
   
   // Load information from the event
   const {
@@ -275,7 +277,7 @@ async function computeShadow(event) {
   const shouldComputeVision = metadata[`${ID}/visionEnabled`] === true;
   if (!shouldComputeVision || playersWithVision.length == 0) {
     // Clear fog
-    await OBR.scene.items.deleteItems(allItems.filter(isVisionFog).map(fogItem => fogItem.id));
+    await OBR.scene.local.deleteItems(localItems.filter(isVisionFog).map(fogItem => fogItem.id));
     busy = false;
     return;
   }
@@ -491,12 +493,12 @@ async function computeShadow(event) {
   computeTimer.pause(); awaitTimer.resume();
 
   const promisesToExecute = [
-    OBR.scene.items.addItems(itemsToAdd.map(item => {
+    OBR.scene.local.addItems(itemsToAdd.map(item => {
       const path = buildPath().commands(item.cmds).locked(true).visible(item.visible).fillColor("#000000").strokeColor("#000000").layer("FOG").name("Fog of War").metadata({[`${ID}/isVisionFog`]: true}).build();
       path.zIndex = item.zIndex;
       return path;
     })),
-    OBR.scene.items.deleteItems(allItems.filter(isVisionFog).map(fogItem => fogItem.id)),
+    OBR.scene.local.deleteItems(localItems.filter(isVisionFog).map(fogItem => fogItem.id)),
   ];
 
   if (!sceneCache.fog.filled)


### PR DESCRIPTION
The `local` property on the `OBR.scene` API allows you to add items that are only visible to the current player.
The benefits of this is that there is no networking involved so it is more efficient.
In this case there are also a lot more benefits.

There are some issues with use the `onChange` event to trigger an item update namely because of network lag.

Here's a timeline of a change:

* User 1 updates the scene (let's call this update `A`)
* User 1's extension receives the `onChange` event for `A`
* User 1 starts preparing the fog update with the new character locations (`B`)
* User 1 sends update `A` over the network to User 2
* User 1 sends update `B` over the network to User 2
* User 2 receives update `A`
* User 2's extension receives the `onChange` event for `A`
* User 2 starts preparing a new fog update (`C`) with the same result as `B`
* User 2 receives update `B`
* User 2 sends the redundent update `C` to User 1

Because of the network lag User 2 sends back a redundent update to User 1.
This scales with the number of users in to a room so if there are 5 users the update will be created and send 5 times.

Currently the extension avoids this by designating a single person who can make updates to the Fog.
It does this by making it so only the GM can update the fog.

But this has a few downsides:
1. If the GM isn't online then players cannot update the fog
2. Fog updates for players will have heavy lag because there needs to be a round trip of a token update being sent to the GM and then the GM sending the fog back
3. Owlbear Rodeo doesn't have a 1-1 relationship of GMs to rooms. A user can have multiple GMs in the same room. This means in a multi-GM room you will run into the redundent update issue above.

To solve all these problems we can create all fog shapes locally and not sync them over the network.
This is because dynamic fog has a nice property where it is calculated from a base set of inputs (player positions and walls) and as long as those things are synced then the fog will be the same.

So what this PR does is make it so each individual user is responsible for creating their own fog shapes.
Because of this no network requests are made in response to the `onChange` event.
This means we sidestep the entire issue with redundent events being sent.
In order to do this the fog logic has to be loaded on all users PCs instead of just the GM.
But this has the added benefit that the fog should now be almost instantly responsive to player changes.

I added some comments but now that the extension is loaded for players as well it means that the extension UI is also interactive for a player.
If you don't want players to be able to interact with fog then you could show a different UI for players but allow them to process `onChange` events.